### PR TITLE
feat(index): use electron-window

### DIFF
--- a/lib/delegate-electron-events.js
+++ b/lib/delegate-electron-events.js
@@ -1,0 +1,43 @@
+const EventEmitter = require('events').EventEmitter
+const { app, ipcMain } = require('electron')
+
+module.exports = delegateElectronEvents
+
+// delegate electron events while booting
+// until a window is ready that can handle them
+function delegateElectronEvents () {
+  var file = null
+  var link = null
+  var win = null
+
+  app.on('will-finish-launching', () => {
+    app.on('open-file', (ev, path) => {
+      ev.preventDefault()
+      if (win) ee.emit('open-file', path)
+      else file = path
+    })
+
+    app.on('open-url', (ev, url) => {
+      ev.preventDefault()
+      if (win) ee.emit('open-url', url)
+      else link = url
+    })
+  })
+
+  const ee = new EventEmitter()
+
+  ipcMain.on('ready', () => {
+    if (file) {
+      let path = file
+      file = null
+      ee.emit('open-file', path)
+    }
+    if (link) {
+      let url = link
+      link = null
+      ee.emit('open-url', url)
+    }
+  })
+
+  return ee
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "dat-js": "^3.8.0",
     "electron": "1.4.6",
     "electron-default-menu": "^1.0.0",
+    "electron-window": "^0.8.1",
+    "envobj": "^1.0.2",
     "hyperdrive-stats": "^2.2.5",
     "insert-css": "^1.0.0",
     "js-alert": "^1.0.4",


### PR DESCRIPTION
Lil maintenance patch to clean up `index.js` - gives us some room to add more features. Think this is cool because it turns the entry file for electron into something that weighs 30 lines of code that's easy to follow :sparkles:

## Changes
- use `envobj` to validate environment variables
- create `lib/delegate-electron-events` to wrap boilerplate in `index.js`, needed to safely delegate file and link events sent to electron while booting (should turn into a package at some point probably)
- use `electron-window` to remove some of the browser boot boilerplate