### PR TITLE
add unstyled welcome screen

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,15 +1,24 @@
+const persist = require('choo-persist')
 const mount = require('choo/mount')
 const log = require('choo-log')
+const xtend = require('xtend')
 const choo = require('choo')
 
-const mainView = require('./pages/main')
+const opts = {
+  filter: (state) => {
+    state = xtend(state)
+    delete state.app
+    return state
+  }
+}
 
-const app = choo()
-app.use(log())
+persist(opts, (p) => {
+  const app = choo()
+  app.use(log())
+  app.use(p)
 
-// import & init models
-app.model(require('./models/app')())
+  app.model(require('./models/app')())
 
-// start
-app.router(['/', mainView])
-mount('body', app.start())
+  app.router(['/', require('./pages/main')])
+  mount('body', app.start())
+})

--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ const choo = require('choo')
 const opts = {
   filter: (state) => {
     state = xtend(state)
-    delete state.app
+    delete state.repos
     return state
   }
 }
@@ -17,7 +17,8 @@ persist(opts, (p) => {
   app.use(log())
   app.use(p)
 
-  app.model(require('./models/app')())
+  app.model(require('./models/main-view')())
+  app.model(require('./models/repos')())
 
   app.router(['/', require('./pages/main')])
   mount('body', app.start())

--- a/elements/table.js
+++ b/elements/table.js
@@ -94,19 +94,19 @@ function createTable (dats, send) {
               icon: 'open-in-finder',
               text: '',
               cls: 'row-action',
-              click: () => send('app:open', dat)
+              click: () => send('repos:open', dat)
             })}
             ${button({
               icon: 'link',
               text: '',
               cls: 'row-action',
-              click: () => send('app:share', dat)
+              click: () => send('repos:share', dat)
             })}
             ${button({
               icon: 'delete',
               text: '',
               cls: 'row-action',
-              click: () => send('app:delete', dat)
+              click: () => send('repos:delete', dat)
             })}
           </div>
         </td>

--- a/models/main-view.js
+++ b/models/main-view.js
@@ -1,0 +1,14 @@
+const Model = require('choo-model')
+
+module.exports = createModel
+
+function createModel (cb) {
+  const model = Model('mainView')
+
+  model.state({ showWelcomeScreen: true })
+  model.reducer('closeWelcomeScreen', (state, action) => {
+    return { showWelcomeScreen: false }
+  })
+
+  return model.start()
+}

--- a/models/repos.js
+++ b/models/repos.js
@@ -9,13 +9,13 @@ const Manager = require('../lib/dat-manager')
 module.exports = createModel
 
 function createModel (cb) {
-  const model = Model('app')
+  const model = Model('repos')
 
   const manager = new Manager()
 
   model.subscription('manager', (send, done) => {
     manager.on('update', () => {
-      send('app:updateArchives', manager.get(), done)
+      send('repos:updateArchives', manager.get(), done)
     })
   })
 

--- a/models/repos.js
+++ b/models/repos.js
@@ -15,14 +15,14 @@ function createModel (cb) {
 
   model.subscription('manager', (send, done) => {
     manager.on('update', () => {
-      send('repos:updateArchives', manager.get(), done)
+      send('repos:update', manager.get(), done)
     })
   })
 
-  model.reducer('updateArchives', (state, data) => {
+  model.reducer('update', (state, data) => {
     return {
       updateIndex: state.updateIndex + 1,
-      archives: data
+      values: data
     }
   })
 
@@ -30,7 +30,7 @@ function createModel (cb) {
   // data structure is mutable
   model.state({
     updateIndex: 0,
-    archives: []
+    values: []
   })
 
   model.effect('open', (state, dat) => {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "choo": "^4.0.0-6",
     "choo-log": "^3.0.0",
     "choo-model": "^1.0.0",
+    "choo-persist": "^2.0.0",
     "collect-stream": "^1.1.1",
     "dat-colors": "^2.0.0",
     "dat-encoding": "^3.0.0",

--- a/pages/main.js
+++ b/pages/main.js
@@ -76,11 +76,11 @@ module.exports = mainView
 // (obj, obj, fn) -> html
 function mainView (state, prev, send) {
   const modalLink = state.location.search.modal
-  const dats = state.app.archives
+  const dats = state.repos.archives
 
   const header = Header({
-    create: () => send('app:create'),
-    download: (link) => send('app:download', link)
+    create: () => send('repos:create'),
+    download: (link) => send('repos:download', link)
   })
 
   if (!dats.length) {

--- a/pages/main.js
+++ b/pages/main.js
@@ -75,13 +75,23 @@ module.exports = mainView
 // render the main view
 // (obj, obj, fn) -> html
 function mainView (state, prev, send) {
+  const showWelcomeScreen = state.mainView.showWelcomeScreen
   const modalLink = state.location.search.modal
-  const dats = state.repos.archives
+  const dats = state.repos.values
 
   const header = Header({
     create: () => send('repos:create'),
     download: (link) => send('repos:download', link)
   })
+
+  if (showWelcomeScreen) {
+    return html`
+      <body>
+        ${svgSprite()}
+        ${WelcomeScreen({ onexit: () => send('mainView:closeWelcomeScreen') })}
+      </body>
+    `
+  }
 
   if (!dats.length) {
     return html`
@@ -110,6 +120,16 @@ function mainView (state, prev, send) {
       ${header}
       ${Table(dats, send)}
     </body>
+  `
+}
+
+function WelcomeScreen (methods) {
+  const onExit = methods.onexit
+  return html`
+    <main>
+      <p>Welcome to dat desktop!</p>
+      <button onclick=${onExit}>Close screen</button>
+    </main>
   `
 }
 


### PR DESCRIPTION
- renamed `models/app` to `models/repos`
- created a `main-view` model used to handle the state from `views/main`
- added `choo-persist` v2 that auto-persists all state except `models/repos` to `IndexedDB`. `models/repos` cannot be persisted because the values inside it cannot be serialized
- created a welcome screen that's shown the first time you boot up the application - didn't do any styling so @Kriesse can do her thing

---
## See Also
- https://github.com/datproject/dat-desktop/issues/68

---
## Screenshot

<img width="1280" alt="screen shot 2016-12-10 at 01 52 01" src="https://cloud.githubusercontent.com/assets/2467194/21069594/d6f91bec-be7b-11e6-9488-fed174b7f100.png">
