### PR TITLE
use open to open files

### DIFF
--- a/models/repos.js
+++ b/models/repos.js
@@ -1,8 +1,8 @@
 const dialog = require('electron').remote.dialog
 const ipc = require('electron').ipcRenderer
-const exec = require('child_process').exec
 const encoding = require('dat-encoding')
 const Model = require('choo-model')
+const open = require('open')
 
 const Manager = require('../lib/dat-manager')
 
@@ -34,8 +34,7 @@ function createModel (cb) {
   })
 
   model.effect('open', (state, dat) => {
-    // TODO cross platform
-    exec(`open "${dat.dir}"`, err => {
+    open(dat.dir, (err) => {
       if (err) throw err
     })
   })

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "level": "^1.4.0",
     "minimist": "^1.2.0",
     "on-load": "^3.2.0",
+    "open": "0.0.5",
     "prettier-bytes": "^1.0.3",
     "sheetify": "^6.0.0",
     "subleveldown": "^2.1.0",


### PR DESCRIPTION
Uses `opener` for cross-platform file opening compat. Had to fork it because of an issue with the Acorn parser, which is solved by https://github.com/domenic/opener/pull/22 - I've pointed it to our fork in the mean time. Thanks! :sparkles: