### PR TITLE
fix bundle not to contain absolute paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,14 @@
       ]
     ]
   },
+  "aliasify": {
+    "aliases": {
+      "bindings": "bindings-browserify"
+    }
+  },
   "dependencies": {
-    "bindingify": "^1.0.0",
+    "aliasify": "^2.1.0",
+    "bindings-browserify": "^2.0.0",
     "bytewise": "^1.1.0",
     "cache-element": "^2.0.0",
     "choo": "^4.0.0-6",
@@ -49,8 +55,8 @@
     "yo-yo": "^1.3.1"
   },
   "scripts": {
-    "bundle": "browserify --fast --ignore-missing --node --full-paths --exclude=electron -g bindingify app.js > bundle.js",
-    "watch": "watchify --fast --ignore-missing --node --full-paths --exclude=electron -g bindingify app.js --verbose -o bundle.js",
+    "bundle": "browserify --fast --ignore-missing --no-builtins --insert-global-vars=\"__filename,__dirname\" --no-browser-field --exclude=electron -g bindings-browserify/transform -g aliasify app.js > bundle.js",
+    "watch": "watchify --fast --ignore-missing --no-builtins --insert-global-vars=\"__filename,__dirname\" --no-browser-field --exclude=electron -g bindings-browserify/transform -g aliasify app.js --verbose -o bundle.js",
     "deps": "dependency-check package.json app.js",
     "rebuild": "./scripts/build rebuild",
     "clean": "rm -rf node_modules/",
@@ -62,7 +68,7 @@
     "dist": "build"
   },
   "devDependencies": {
-    "browserify": "^13.1.1",
+    "browserify": "juliangruber/node-browserify#fix/dat-desktop",
     "bulkify": "^1.4.2",
     "dependency-check": "^2.6.0",
     "electron": "1.4.6",


### PR DESCRIPTION
Prior to this the browserify bundles would contain paths like `/Users/julian/...` which wouldn't work on other machines, as @Kriesse noticed.

To fix this, I had to remove the `--no-commondir` option (by removing `--node` which required it and adding back the remaining options of `--node`). This would end us up with paths like `/node_modules/leveldown/...` though, which also wouldn't work. Paths need to be `./node_modules/leveldown/...` etc.

To fix this, I first forked the bindings module to https://github.com/juliangruber/bindings-browserify, which makes paths relative here: https://github.com/juliangruber/bindings-browserify/blob/master/index.js#L71. We're using the aliasify module (https://github.com/benbria/aliasify) to make every module require that instead of the regular bindings module. We can't just use the browser field feature of browserify here, because we needed to disable it for the build to work properly.

I also needed to make a patch to insert-module-globals: https://github.com/substack/insert-module-globals/pull/66. This makes sure, all the other path logic still works, like `fs.readFileSync("icons.svg")`. Until it's merged, we can use my fork of browserify which in turn requires this module.

The solution isn't simple. But it works for now.