### PR TITLE
Fix browserify bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,21 +6,6 @@
   "repository": "datproject/dat-desktop",
   "description": "Dat Desktop App",
   "author": "Dat Team",
-  "browserify": {
-    "transform": [
-      [
-        "sheetify/transform",
-        {
-          "use": "sheetify-nested"
-        }
-      ]
-    ]
-  },
-  "aliasify": {
-    "aliases": {
-      "bindings": "bindings-browserify"
-    }
-  },
   "dependencies": {
     "aliasify": "^2.1.0",
     "bindings-browserify": "^2.0.0",
@@ -56,7 +41,7 @@
   },
   "scripts": {
     "bundle": "scripts/browserify.js",
-    "watch": "watchify --fast --ignore-missing --no-builtins --insert-global-vars=\"__filename,__dirname\" --no-browser-field --exclude=electron -g bindings-browserify/transform -g aliasify app.js --verbose -o bundle.js",
+    "watch": "scripts/browserify.js watch",
     "deps": "dependency-check package.json app.js",
     "rebuild": "./scripts/build rebuild",
     "clean": "rm -rf node_modules/",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "yo-yo": "^1.3.1"
   },
   "scripts": {
-    "bundle": "browserify --fast --ignore-missing --no-builtins --insert-global-vars=\"__filename,__dirname\" --no-browser-field --exclude=electron -g bindings-browserify/transform -g aliasify app.js > bundle.js",
+    "bundle": "scripts/browserify.js",
     "watch": "watchify --fast --ignore-missing --no-builtins --insert-global-vars=\"__filename,__dirname\" --no-browser-field --exclude=electron -g bindings-browserify/transform -g aliasify app.js --verbose -o bundle.js",
     "deps": "dependency-check package.json app.js",
     "rebuild": "./scripts/build rebuild",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "dist": "build"
   },
   "devDependencies": {
-    "browserify": "juliangruber/node-browserify#fix/dat-desktop",
+    "browserify": "^13.3.0",
     "bulkify": "^1.4.2",
     "dependency-check": "^2.6.0",
     "electron": "1.4.6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "author": "Dat Team",
   "dependencies": {
     "aliasify": "^2.1.0",
-    "bindings-browserify": "^2.0.0",
     "bytewise": "^1.1.0",
     "cache-element": "^2.0.0",
     "choo": "^4.0.0-6",
@@ -53,6 +52,7 @@
     "dist": "build"
   },
   "devDependencies": {
+    "bindingify": "^1.0.1",
     "browserify": "^13.3.0",
     "bulkify": "^1.4.2",
     "dependency-check": "^2.6.0",

--- a/scripts/browserify.js
+++ b/scripts/browserify.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+const browserify = require('browserify')
+const fs = require('fs')
+
+const b = browserify(`${__dirname}/../app.js`, {
+  insertGlobals: true,
+  ignoreMissing: true,
+  builtins: false,
+  browserField: false,
+  insertGlobalVars: {
+    'process': undefined,
+    'global': undefined,
+    'Buffer': undefined,
+    'Buffer.isBuffer': undefined
+  }
+})
+
+b.exclude('electron')
+b.transform('bindings-browserify/transform', {
+  global: true
+})
+b.transform('aliasify', {
+  global: true,
+  aliases: {
+    bindings: 'bindings-browserify'
+  }
+})
+b.transform('sheetify/transform', {
+  use: ['sheetify-nested']
+})
+
+b.bundle().pipe(fs.createWriteStream(`${__dirname}/../bundle.js`))

--- a/scripts/browserify.js
+++ b/scripts/browserify.js
@@ -3,6 +3,7 @@
 const browserify = require('browserify')
 const watchify = require('watchify')
 const fs = require('fs')
+const path = require('path')
 
 const watch = process.argv[2] === 'watch'
 
@@ -12,6 +13,14 @@ const opts = {
   builtins: false,
   browserField: false,
   insertGlobalVars: {
+    '__dirname': (file, basedir) => {
+      var dir = path.dirname('./' + path.relative(basedir, file))
+      return JSON.stringify(dir)
+    },
+    '__filename': (file, basedir) => {
+      var filename = './' + path.relative(basedir, file)
+      return JSON.stringify(filename)
+    },
     'process': undefined,
     'global': undefined,
     'Buffer': undefined,

--- a/scripts/browserify.js
+++ b/scripts/browserify.js
@@ -14,12 +14,12 @@ const opts = {
   browserField: false,
   insertGlobalVars: {
     '__dirname': (file, basedir) => {
-      var dir = path.dirname('./' + path.relative(basedir, file))
-      return JSON.stringify(dir)
+      return '__dirname + "/" + ' +
+        JSON.stringify(path.dirname(path.relative(basedir, file)))
     },
     '__filename': (file, basedir) => {
-      var filename = './' + path.relative(basedir, file)
-      return JSON.stringify(filename)
+      return '__filename + "/" + ' +
+        JSON.stringify(path.relative(basedir, file))
     },
     'process': undefined,
     'global': undefined,
@@ -37,18 +37,8 @@ if (watch) {
 const b = browserify(`${__dirname}/../app.js`, opts)
 
 b.exclude('electron')
-b.transform('bindings-browserify/transform', {
-  global: true
-})
-b.transform('aliasify', {
-  global: true,
-  aliases: {
-    bindings: 'bindings-browserify'
-  }
-})
-b.transform('sheetify/transform', {
-  use: ['sheetify-nested']
-})
+b.transform('bindingify', { global: true })
+b.transform('sheetify/transform', { use: ['sheetify-nested'] })
 
 const bundle = () => {
   process.stderr.write(`${new Date()} bundling...`)


### PR DESCRIPTION
`__dirname` is now being resolved correctly, so it will work on any machine and in the packaged app as well. Also as a benefit not the `"bundle"` and the `"watch"` scripts always use the same browserify arguments.