### PR TITLE
move back to rebuild script

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "bundle": "scripts/browserify.js",
     "watch": "scripts/browserify.js watch",
     "deps": "dependency-check package.json app.js",
-    "rebuild": "npm rebuild --runtime=electron --target=1.4.6 --disturl=https://atom.io/download/atom-shell --build-from-source",
+    "rebuild": "./scripts/build rebuild",
     "burnthemall": "rm -rf ~/.electron && npm run clean && npm install && npm run rebuild && npm run bundle",
     "clean": "rm -rf node_modules/",
     "build-background": "./scripts/build background",

--- a/scripts/build
+++ b/scripts/build
@@ -12,7 +12,9 @@ rebuild () {
     --runtime=electron \
     --target="$electron_version" \
     --disturl=https://atom.io/download/atom-shell \
-    --abi="$electron_abi" > /dev/null
+    --abi="$electron_abi" \
+    --build-from-source \
+    > /dev/null
 }
 
 build_background () {


### PR DESCRIPTION
Adding the `--build-from-source` flag fixed issues for @karissa installing the deps. While this bypasses prebuild logic and we should investigate why that fixes it, it seems to work for now.

This PR moves the build logic back to our build script.