### PR TITLE
only run choo-log in development

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,8 +22,11 @@ const opts = {
 
 persist(opts, (p) => {
   const app = choo()
-  app.use(log())
   app.use(p)
+
+  if (process.env.NODE_ENV === 'development') {
+    app.use(log())
+  }
 
   app.model(require('./models/main-view')())
   app.model(require('./models/window')())

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "dependency-check": "^2.6.0",
     "electron": "1.4.14",
     "electron-builder": "^8.6.0",
+    "envify": "^4.0.0",
     "nodemon": "^1.9.2",
     "sheetify-nested": "^1.0.2",
     "standard": "^7.1.2",

--- a/scripts/browserify.js
+++ b/scripts/browserify.js
@@ -38,6 +38,7 @@ const b = browserify(`${__dirname}/../app.js`, opts)
 
 b.exclude('electron')
 b.transform('bindingify', { global: true })
+b.transform('envify')
 b.transform('sheetify/transform', { use: ['sheetify-nested'] })
 
 const bundle = () => {


### PR DESCRIPTION
Should help boost performance a lil; ref https://github.com/datproject/dat-desktop/issues/152
- start using `envify` to hardcode strings for production
- only run `choo-log` if `NODE_ENV` is development