### PR TITLE
fix sodium-prebuilt using updated bindingify

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "dist": "build"
   },
   "devDependencies": {
-    "bindingify": "yoshuawuyts/bindingify#fix/sodium",
     "browserify": "^13.3.0",
     "bulkify": "^1.4.2",
     "dependency-check": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "dist": "build"
   },
   "devDependencies": {
-    "bindingify": "^1.0.1",
+    "bindingify": "yoshuawuyts/bindingify#fix/sodium",
     "browserify": "^13.3.0",
     "bulkify": "^1.4.2",
     "dependency-check": "^2.6.0",

--- a/scripts/browserify.js
+++ b/scripts/browserify.js
@@ -25,6 +25,12 @@ const opts = {
     'global': undefined,
     'Buffer': undefined,
     'Buffer.isBuffer': undefined
+  },
+  postFilter: (id, file, pkg) => {
+    if (file.indexOf('node_modules') > -1 && file.indexOf('sheetify') === -1) {
+      return false
+    }
+    return true
   }
 }
 
@@ -36,10 +42,6 @@ if (watch) {
 
 const b = browserify(`${__dirname}/../app.js`, opts)
 
-b.exclude('electron')
-b.exclude('level')
-b.exclude('dat-doctor')
-b.exclude('dat-node')
 b.transform('envify')
 b.transform('sheetify/transform', { use: ['sheetify-nested'] })
 

--- a/scripts/browserify.js
+++ b/scripts/browserify.js
@@ -37,7 +37,9 @@ if (watch) {
 const b = browserify(`${__dirname}/../app.js`, opts)
 
 b.exclude('electron')
-b.transform('bindingify', { global: true })
+b.exclude('level')
+b.exclude('dat-doctor')
+b.exclude('dat-node')
 b.transform('envify')
 b.transform('sheetify/transform', { use: ['sheetify-nested'] })
 

--- a/scripts/browserify.js
+++ b/scripts/browserify.js
@@ -37,7 +37,6 @@ if (watch) {
 const b = browserify(`${__dirname}/../app.js`, opts)
 
 b.exclude('electron')
-b.exclude('dat-node')
 b.transform('bindingify', { global: true })
 b.transform('envify')
 b.transform('sheetify/transform', { use: ['sheetify-nested'] })


### PR DESCRIPTION
@Kriesse can you give this a try? This should fix the sodium errors without special casing any dependency.