### PR TITLE
scripts/build: remove --build-from-source

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -13,7 +13,6 @@ rebuild () {
     --target="$electron_version" \
     --disturl=https://atom.io/download/atom-shell \
     --abi="$electron_abi" \
-    --build-from-source \
     > /dev/null
 }
 


### PR DESCRIPTION
Originally introduced to fix native dependency issues, we found
out that browserify configuration was to blame instead. So this
enables prebuild installs again!