### PR TITLE
fix bundle if dat-desktop parent is node_modules folder

### DIFF
--- a/scripts/browserify.js
+++ b/scripts/browserify.js
@@ -28,6 +28,7 @@ const opts = {
   },
   postFilter: (id, file, pkg) => {
     if (!file) return false
+    file = path.relative(path.join(__dirname, '..'), file)
     if (file.indexOf('node_modules') > -1 && file.indexOf('sheetify') === -1) {
       return false
     }


### PR DESCRIPTION
My bundle was not working because the path of the repo included `node_modules`. Make sure we only ignore node_module files relative to the repo directory.