### PR TITLE
Do not capitalize author

### DIFF
--- a/elements/table.js
+++ b/elements/table.js
@@ -228,7 +228,7 @@ function createTable (dats, send) {
               ${dat.title || `#${encoding.encode(dat.key)}`}
             </h2>
             <p class="f7 color-neutral-60 truncate">
-              <span class="ttc">${dat.author || 'Anonymous'} • </span>
+              <span class="">${dat.author || 'Anonymous'} • </span>
               <span>
                 ${dat.owner
                   ? 'Read & Write'


### PR DESCRIPTION
Doing text transform capitalize can lead to weird author things like: 

<img width="241" alt="screen shot 2017-02-01 at 11 57 30" src="https://cloud.githubusercontent.com/assets/684965/22523959/1e034692-e876-11e6-8ec9-b6b1da04ebce.png">

Also some people like their name lower case. We should use whatever the author specified.