### PR TITLE
add soon required insert-css dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "explain-error": "^1.0.3",
     "global": "^4.3.1",
     "hyperdrive-stats": "^2.2.5",
+    "insert-css": "^1.1.0",
     "level": "^1.4.0",
     "minimist": "^1.2.0",
     "ms": "^0.7.2",


### PR DESCRIPTION
npm3 doesn't automatically install peer dependencies any more. we're currently getting a warning about this.