### PR TITLE
reset welcome screen

### DIFF
--- a/models/main-view.js
+++ b/models/main-view.js
@@ -1,17 +1,38 @@
+var assert = require('assert')
+
 module.exports = createModel
 
 function createModel (cb) {
   return {
     namespace: 'mainView',
+    subscriptions: {
+      start: start
+    },
+    effects: {
+      loadWelcomeScreen: loadWelcomeScreen
+    },
     state: {
-      showWelcomeScreen: true
+      welcome: true
     },
     reducers: {
-      closeWelcomeScreen: closeWelcomeScreen
+      toggleWelcomeScreen: toggleWelcomeScreen
     }
   }
 }
 
-function closeWelcomeScreen (state, action) {
-  return { showWelcomeScreen: false }
+function start (send, done) {
+  send('mainView:loadWelcomeScreen', done)
+}
+
+function loadWelcomeScreen (state, action, send, done) {
+  send('repos:shareState', function (err, reposState) {
+    if (err) return done(err)
+    if (reposState.values.length) return done()
+    send('mainView:toggleWelcomeScreen', { toggle: true }, done)
+  })
+}
+
+function toggleWelcomeScreen (state, data, action) {
+  assert.equal(typeof data.toggle, 'boolean', 'models/main-view: toggle should be a boolean')
+  return { welcome: data.toggle }
 }

--- a/models/repos.js
+++ b/models/repos.js
@@ -40,8 +40,15 @@ function createModel (cb) {
       delete: deleteDat,
       download: downloadDat,
       'add-dir': addDirectory,
-      deleteConfirm: deleteConfirmed
+      deleteConfirm: deleteConfirmed,
+      shareState: shareState
     }
+  }
+
+  // note: this is a slight hack; next version of choo will
+  // allow effects to have access to all state
+  function shareState (state, action, send, done) {
+    done(null, state)
   }
 
   function handleManagerUpdate (send, done) {

--- a/pages/main.js
+++ b/pages/main.js
@@ -74,7 +74,7 @@ module.exports = mainView
 // render the main view
 // (obj, obj, fn) -> html
 function mainView (state, prev, send) {
-  const showWelcomeScreen = state.mainView.showWelcomeScreen
+  const showWelcomeScreen = state.mainView.welcome
   const dats = state.repos.values
 
   const header = Header({
@@ -82,11 +82,16 @@ function mainView (state, prev, send) {
     download: (link) => send('repos:download', link)
   })
 
+  document.title = 'Dat Desktop'
+
   if (showWelcomeScreen) {
+    document.title = 'Dat Desktop | Welcome'
     return html`
       <body>
         ${sprite()}
-        ${WelcomeScreen({ onexit: () => send('mainView:closeWelcomeScreen') })}
+        ${WelcomeScreen({
+          onexit: () => send('mainView:toggleWelcomeScreen', { toggle: false })
+        })}
       </body>
     `
   }


### PR DESCRIPTION
> welcome screen should show every time you open the app as long as you have no dats

Show welcome screen when no dats are available as per https://github.com/datproject/dat-desktop/issues/138