### PR TITLE
make sure that create new dat works as intended with stats

### DIFF
--- a/elements/status.js
+++ b/elements/status.js
@@ -1,0 +1,101 @@
+const html = require('choo/html')
+const css = require('sheetify')
+
+const progressbar = css`
+  :host {
+    --progress-height: .5rem;
+    --bar-height: var(--progress-height);
+    --counter-width: 2.5rem;
+
+    min-width: 8rem;
+    overflow: hidden;
+    padding-top: .85rem;
+    padding-bottom: .5rem;
+    .bar {
+      height: var(--progress-height);
+      width: calc(100% - var(--counter-width));
+      float: left;
+      overflow: hidden;
+      background-color: var(--color-neutral-20);
+      border-radius: 2px;
+    }
+    .line {
+      width: 0%;
+      height: var(--progress-height);
+      background-color: var(--color-blue);
+      border-radius: 2px;
+    }
+    .line-loading {
+      --tile-width: 28px;
+      --stripe-width: 5px;
+      @keyframes move-bg {
+        0% {
+          background-position: var(--tile-width) 0;
+        }
+        100% {
+          background-position: 0 0;
+        }
+      };
+      overflow: hidden;
+      position: relative;
+      height: var(--bar-height);
+      &:before {
+        content: '';
+        width: 100%;
+        height: var(--bar-height);
+        position: absolute;
+        top: 0;
+        left: 0;
+        background-image: repeating-linear-gradient(
+          -45deg,
+          transparent,
+          transparent var(--stripe-width),
+          rgba(255,255,255,.1) var(--stripe-width),
+          rgba(255,255,255,.1) calc(2 * var(--stripe-width))
+        );
+        background-size: var(--tile-width) var(--bar-height);
+        animation: move-bg .75s linear infinite;
+      }
+    }
+    .line-complete {
+      background-color: var(--color-green);
+    }
+    .line-paused {
+      background-color: var(--color-neutral-40);
+    }
+    .counter {
+      float: right;
+      min-width: var(--counter-width);
+      margin-top: -.4rem;
+      text-align: right;
+      font-size: .875rem;
+    }
+  }
+`
+module.exports = function (dat, stats, send) {
+  if (dat.owner && dat.importer) {
+    return html`<div>Watching for updates...</div>`
+  }
+  var progressbarLine = (stats.state === 'loading')
+    ? 'line-loading'
+    : (stats.state === 'paused')
+      ? 'line-paused'
+      : 'line-complete'
+
+  // place an upper bound of 100% on progress. We've encountered situations
+  // where blocks downloaded exceeds total block. Once that's fixed this
+  // should be safe to be removed
+  var progress = Math.min(stats.progress, 100)
+
+  return html`
+    <div class="${progressbar}">
+      <div class="counter">
+        ${progress}%
+      </div>
+      <div class="bar">
+        <div class="line ${progressbarLine}" style="width: ${progress}%">
+        </div>
+      </div>
+    </div>
+  `
+}

--- a/elements/status.js
+++ b/elements/status.js
@@ -82,18 +82,13 @@ module.exports = function (dat, stats, send) {
       ? 'line-paused'
       : 'line-complete'
 
-  // place an upper bound of 100% on progress. We've encountered situations
-  // where blocks downloaded exceeds total block. Once that's fixed this
-  // should be safe to be removed
-  var progress = Math.min(stats.progress, 100)
-
   return html`
     <div class="${progressbar}">
       <div class="counter">
-        ${progress}%
+        ${stats.progress}%
       </div>
       <div class="bar">
-        <div class="line ${progressbarLine}" style="width: ${progress}%">
+        <div class="line ${progressbarLine}" style="width: ${stats.progress}%">
         </div>
       </div>
     </div>

--- a/elements/table.js
+++ b/elements/table.js
@@ -130,6 +130,11 @@ function createTable (dats, send) {
           ? Math.round((stats.blocksProgress / stats.blocksTotal) * 100)
           : 0
 
+    // place an upper bound of 100% on progress. We've encountered situations
+    // where blocks downloaded exceeds total block. Once that's fixed this
+    // should be safe to be removed
+    stats.progress = Math.min(stats.progress, 100)
+
     stats.state = (dat.owner)
       ? 'complete'
       : (stats.progress === 100)
@@ -169,7 +174,7 @@ function createTable (dats, send) {
           ${status(dat, stats, send)}
         </td>
         <td class="tr cell-4">
-          ${(dat.archive.content.bytes) ? bytes(dat.archive.content.bytes) : 'N/A'}
+          ${(dat.archive.content) ? bytes(dat.archive.content.bytes) : 'N/A'}
         </td>
         <td class="tr cell-5">
           ${icon({

--- a/elements/table.js
+++ b/elements/table.js
@@ -3,6 +3,7 @@ const bytes = require('prettier-bytes')
 const html = require('choo/html')
 const css = require('sheetify')
 
+const status = require('./status')
 const button = require('./button')
 const icon = require('./icon')
 
@@ -93,78 +94,6 @@ const table = css`
   }
 `
 
-const progressbar = css`
-  :host {
-    --progress-height: .5rem;
-    --bar-height: var(--progress-height);
-    --counter-width: 2.5rem;
-
-    min-width: 8rem;
-    overflow: hidden;
-    padding-top: .85rem;
-    padding-bottom: .5rem;
-    .bar {
-      height: var(--progress-height);
-      width: calc(100% - var(--counter-width));
-      float: left;
-      overflow: hidden;
-      background-color: var(--color-neutral-20);
-      border-radius: 2px;
-    }
-    .line {
-      width: 0%;
-      height: var(--progress-height);
-      background-color: var(--color-blue);
-      border-radius: 2px;
-    }
-    .line-loading {
-      --tile-width: 28px;
-      --stripe-width: 5px;
-      @keyframes move-bg {
-        0% {
-          background-position: var(--tile-width) 0;
-        }
-        100% {
-          background-position: 0 0;
-        }
-      };
-      overflow: hidden;
-      position: relative;
-      height: var(--bar-height);
-      &:before {
-        content: '';
-        width: 100%;
-        height: var(--bar-height);
-        position: absolute;
-        top: 0;
-        left: 0;
-        background-image: repeating-linear-gradient(
-          -45deg,
-          transparent,
-          transparent var(--stripe-width),
-          rgba(255,255,255,.1) var(--stripe-width),
-          rgba(255,255,255,.1) calc(2 * var(--stripe-width))
-        );
-        background-size: var(--tile-width) var(--bar-height);
-        animation: move-bg .75s linear infinite;
-      }
-    }
-    .line-complete {
-      background-color: var(--color-green);
-    }
-    .line-paused {
-      background-color: var(--color-neutral-40);
-    }
-    .counter {
-      float: right;
-      min-width: var(--counter-width);
-      margin-top: -.4rem;
-      text-align: right;
-      font-size: .875rem;
-    }
-  }
-`
-
 module.exports = tableElement
 
 function tableElement (dats, send) {
@@ -175,7 +104,7 @@ function tableElement (dats, send) {
           <tr>
             <th class="cell-1"></th>
             <th class="tl cell-2">Link</th>
-            <th class="tl cell-3">Download</th>
+            <th class="tl cell-3">Status</th>
             <th class="tr cell-4">Size</th>
             <th class="tr cell-5">Network</th>
             <th class="cell-6"></th>
@@ -195,22 +124,15 @@ function createTable (dats, send) {
   return dats.map(dat => {
     const stats = dat.stats && dat.stats.get()
     var peers = dat.network.connected
-    let progress = (dat.owner)
-      ? 100
-      : (!stats)
+    stats.progress = (!stats)
         ? 0
         : (stats.blocksTotal)
           ? Math.round((stats.blocksProgress / stats.blocksTotal) * 100)
           : 0
 
-    // place an upper bound of 100% on progress. We've encountered situations
-    // where blocks downloaded exceeds total block. Once that's fixed this
-    // should be safe to be removed
-    progress = Math.min(progress, 100)
-
-    const state = (dat.owner)
+    stats.state = (dat.owner)
       ? 'complete'
-      : (progress === 100)
+      : (stats.progress === 100)
         ? 'complete'
         : (peers === 0)
           ? 'paused'
@@ -220,13 +142,7 @@ function createTable (dats, send) {
       loading: icon({id: 'hexagon-down', cls: 'color-blue'}),
       paused: icon({id: 'hexagon-pause', cls: 'color-neutral-30'}),
       complete: icon({id: 'hexagon-up', cls: 'color-green'})
-    }[state]
-
-    var progressbarLine = (state === 'loading')
-      ? 'line-loading'
-      : (state === 'paused')
-        ? 'line-paused'
-        : 'line-complete'
+    }[stats.state]
 
     return html`
       <tr>
@@ -250,18 +166,10 @@ function createTable (dats, send) {
           </div>
         </td>
         <td class="cell-3">
-          <div class="${progressbar}">
-            <div class="counter">
-              ${progress}%
-            </div>
-            <div class="bar">
-              <div class="line ${progressbarLine}" style="width: ${progress}%">
-              </div>
-            </div>
-          </div>
+          ${status(dat, stats, send)}
         </td>
         <td class="tr cell-4">
-          ${(dat.archive.content) ? bytes(dat.archive.content.bytes) : 'N/A'}
+          ${(dat.archive.content.bytes) ? bytes(dat.archive.content.bytes) : 'N/A'}
         </td>
         <td class="tr cell-5">
           ${icon({

--- a/models/repos.js
+++ b/models/repos.js
@@ -198,7 +198,6 @@ function createManager (multidat, onupdate) {
 
     multidat.create(dir, opts, function (err, dat) {
       if (err) return cb(err)
-
       initDat(dat)
       update()
       cb(null, dat)
@@ -225,6 +224,21 @@ function createManager (multidat, onupdate) {
     var stats = dat.trackStats()
     dat.metadata = dat.metadata || {}
     dat.stats = stats
+
+    if (dat.owner) {
+      var importer = dat.importFiles({
+        watch: true,
+        resume: true,
+        ignoreHidden: true,
+        compareFileContent: true
+      }, function (err) {
+        if (err) throw err
+        update()
+      })
+      importer.on('file imported', function () {
+        update()
+      })
+    }
 
     multidat.readManifest(dat, function (_, manifest) {
       if (!manifest) return


### PR DESCRIPTION
This PR makes sure we are properly importing files into the dat and rendering the status. 

- We weren't calling it at all. Now it'll import the files and update the table on every file import event.
- Modularizes out the progress bar rendering code. 
- Removes the progress bar for local dats that the user owns (shared dats). This is consistent with the CLI. The reason we made this decision in the CLI is that it is very difficult to tell what the progress is for a dat now. So instead, it will say 'Watching for updates' where the progress bar used to be. 
- Because the dats could be downloaded remotely or created locally, the header says 'Status' instead of 'Downloaded'

