### PR TITLE
fix multiple deletions in a row

### DIFF
--- a/elements/confirm-modal.js
+++ b/elements/confirm-modal.js
@@ -32,9 +32,10 @@ const prefix = css`
 module.exports = createWidget
 
 function createWidget () {
-  const modal = Modal({ render, onexit })
-
-  return modal
+  return Modal({
+    render: render,
+    onexit: onexit
+  })
 
   function onexit () {
     window.history.back()
@@ -42,6 +43,20 @@ function createWidget () {
 
   function render (cb) {
     assert.equal(typeof cb, 'function', 'elements/confirm-modal: cb should be a function')
+
+    var deleteButton = button({
+      text: 'Yes, Remove Dat',
+      style: 'filled-green',
+      cls: 'fr ml3',
+      click: ondelete
+    })
+
+    var exitButton = button({
+      text: 'No, Cancel',
+      style: 'plain',
+      cls: 'fr',
+      click: onexit
+    })
 
     return html`
       <section class="relative flex flex-column justify-center ${prefix}">
@@ -54,18 +69,8 @@ function createWidget () {
           This can’t be undone.
         </p>
         <p>
-          ${button({
-            text: 'Yes, Remove Dat',
-            style: 'filled-green',
-            cls: 'fr ml3',
-            click: ondelete
-          })}
-          ${button({
-            text: 'No, Cancel',
-            style: 'plain',
-            cls: 'fr',
-            click: onexit
-          })}
+          ${deleteButton}
+          ${exitButton}
         </p>
         <button
           onclick=${onexit}
@@ -75,6 +80,7 @@ function createWidget () {
         </button>
       </section>
     `
+
     function ondelete () {
       cb()
       onexit()

--- a/elements/table.js
+++ b/elements/table.js
@@ -1,6 +1,7 @@
 const encoding = require('dat-encoding')
 const bytes = require('prettier-bytes')
 const html = require('choo/html')
+const assert = require('assert')
 const css = require('sheetify')
 
 const status = require('./status')
@@ -111,103 +112,119 @@ function tableElement (dats, send) {
           </tr>
         </thead>
         <tbody>
-          ${createTable(dats, send)}
+          ${dats.map(function (dat) {
+            return row(dat, send)
+          })}
         </tbody>
       </table>
     </main>
   `
 }
 
-// create the inner table element
-// ([obj], fn) -> html
-function createTable (dats, send) {
-  return dats.map(dat => {
-    const stats = dat.stats && dat.stats.get()
-    var peers = dat.network.connected
-    stats.progress = (!stats)
-        ? 0
-        : (stats.blocksTotal)
-          ? Math.round((stats.blocksProgress / stats.blocksTotal) * 100)
-          : 0
+function row (dat, send) {
+  const stats = dat.stats && dat.stats.get()
+  var peers = dat.network.connected
+  var key = encoding.encode(dat.key)
+  var title = dat.metadata.title || '#' + key
 
-    // place an upper bound of 100% on progress. We've encountered situations
-    // where blocks downloaded exceeds total block. Once that's fixed this
-    // should be safe to be removed
-    stats.progress = Math.min(stats.progress, 100)
+  stats.progress = (!stats)
+    ? 0
+    : (stats.blocksTotal)
+      ? Math.round((stats.blocksProgress / stats.blocksTotal) * 100)
+      : 0
 
-    stats.state = (dat.owner)
+  // place an upper bound of 100% on progress. We've encountered situations
+  // where blocks downloaded exceeds total block. Once that's fixed this
+  // should be safe to be removed
+  stats.progress = Math.min(stats.progress, 100)
+
+  stats.state = (dat.owner)
+    ? 'complete'
+    : (stats.progress === 100)
       ? 'complete'
-      : (stats.progress === 100)
-        ? 'complete'
-        : (peers === 0)
-          ? 'paused'
-          : 'loading'
+      : (peers === 0)
+        ? 'paused'
+        : 'loading'
 
-    const hexContent = {
-      loading: icon({id: 'hexagon-down', cls: 'color-blue'}),
-      paused: icon({id: 'hexagon-pause', cls: 'color-neutral-30'}),
-      complete: icon({id: 'hexagon-up', cls: 'color-green'})
-    }[stats.state]
+  const hexContent = {
+    loading: icon({id: 'hexagon-down', cls: 'color-blue'}),
+    paused: icon({id: 'hexagon-pause', cls: 'color-neutral-30'}),
+    complete: icon({id: 'hexagon-up', cls: 'color-green'})
+  }[stats.state]
 
-    return html`
-      <tr>
-        <td class="cell-1">
-          <div class="w2 pa1 center">
-            ${hexContent}
-          </div>
-        </td>
-        <td class="cell-2">
-          <div class="cell-truncate">
-            <h2 class="normal truncate">
-              ${dat.metadata.title || `#${encoding.encode(dat.key)}`}
-            </h2>
-            <p class="f7 color-neutral-60 truncate">
-              <span class="">${dat.metadata.author || 'Anonymous'} • </span>
-              <span>
-                ${dat.owner ? 'Read & Write' : 'Read-only'}
-                ${dat.metadata.title && `· #${encoding.encode(dat.key)}`}
-              </span>
-            </p>
-          </div>
-        </td>
-        <td class="cell-3">
-          ${status(dat, stats, send)}
-        </td>
-        <td class="tr cell-4">
-          ${(dat.archive.content) ? bytes(dat.archive.content.bytes) : 'N/A'}
-        </td>
-        <td class="tr cell-5">
-          ${icon({
-            id: 'network'
-          })}
-          ${peers}
-        </td>
-        <td class="cell-6">
-          <div class="flex justify-end">
-            ${button({
-              text: 'Open in Finder',
-              style: 'icon-only',
-              icon: 'open-in-finder',
-              cls: 'row-action',
-              click: () => send('repos:open', dat)
-            })}
-            ${button({
-              text: 'Copy Dat Link',
-              style: 'icon-only',
-              icon: 'link',
-              cls: 'row-action',
-              click: () => send('repos:share', dat)
-            })}
-            ${button({
-              text: 'Remove Dat',
-              style: 'icon-only',
-              icon: 'delete',
-              cls: 'row-action',
-              click: () => send('repos:remove', dat)
-            })}
-          </div>
-        </td>
-      </tr>
-    `
+  var finderButton = button({
+    text: 'Open in Finder',
+    style: 'icon-only',
+    icon: 'open-in-finder',
+    cls: 'row-action',
+    click: () => send('repos:open', dat)
   })
+
+  var linkButton = button({
+    text: 'Copy Dat Link',
+    style: 'icon-only',
+    icon: 'link',
+    cls: 'row-action',
+    click: () => send('repos:share', dat)
+  })
+
+  var deleteButton = button({
+    text: 'Remove Dat',
+    style: 'icon-only',
+    icon: 'delete',
+    cls: 'row-action',
+    click: function (e) {
+      // TODO: we're relying on DOM ordering here. Fix this in choo by moving
+      // to nanomorph; e.g. events are still copied over when reordering
+      var target = e.target
+      while (target.parentNode) {
+        var id = target.getAttribute('id')
+        if (id) break
+        target = target.parentNode
+      }
+      assert.equal(typeof id, 'string', 'elements/table.deleteButton: id should be type string')
+      send('repos:remove', { key: id })
+    }
+  })
+
+  return html`
+    <tr id=${key}>
+      <td class="cell-1">
+        <div class="w2 pa1 center">
+          ${hexContent}
+        </div>
+      </td>
+      <td class="cell-2">
+        <div class="cell-truncate">
+          <h2 class="normal truncate">
+            ${title}
+          </h2>
+          <p class="f7 color-neutral-60 truncate">
+            <span class="">${dat.metadata.author || 'Anonymous'} • </span>
+            <span>
+              ${dat.owner ? 'Read & Write' : 'Read-only'}
+              ${title}
+            </span>
+          </p>
+        </div>
+      </td>
+      <td class="cell-3">
+        ${status(dat, stats, send)}
+      </td>
+      <td class="tr cell-4">
+        ${(dat.archive.content) ? bytes(dat.archive.content.bytes) : 'N/A'}
+      </td>
+      <td class="tr cell-5">
+        ${icon({ id: 'network' })}
+        ${peers}
+      </td>
+      <td class="cell-6">
+        <div class="flex justify-end">
+          ${finderButton}
+          ${linkButton}
+          ${deleteButton}
+        </div>
+      </td>
+    </tr>
+  `
 }

--- a/pages/main-delete.js
+++ b/pages/main-delete.js
@@ -10,7 +10,6 @@ const confirmModal = ConfirmModal()
 module.exports = view
 
 function view (state, prev, send) {
-  const key = state.location.search.delete
   const archives = state.repos.values
   const isReady = state.repos.ready
 
@@ -20,15 +19,19 @@ function view (state, prev, send) {
     onimport: (link) => send('repos:clone', link)
   })
 
+  // TODO: move 'key' out of closure, callback isn't being update
+  // correctly yet has previously been source of not being able to delete
+  // multiple dats in a row.
+  var modal = confirmModal(function () {
+    send('repos:remove', { confirmed: true })
+  })
+
   return html`
     <body>
       ${sprite()}
       ${header}
       ${Table(archives, send)}
-      ${confirmModal(() => send('repos:remove', {
-        confirmed: true,
-        key: key
-      }))}
+      ${modal}
     </body>
   `
 }


### PR DESCRIPTION
This fixes the issue where multiple deletions in a row caused the wrong `dat` to be referenced and crashed the app. The core issue at hand is most likely events not being copied over correctly and referencing old state. Thing seem to point to a `morphdom` issue. Made a note to test this in https://github.com/datproject/dat-desktop/issues/223#issuecomment-279685613.

In the meantime I've solved the issue by creating a temporary variable to store the pending key for deletion.

Had to move a lot of code around to pinpoint the issue; apologies for the rather large diff here.