### PR TITLE
fix createSend syntax

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,11 +50,11 @@ persist(opts, (p) => {
 function onError (action) {
   return {
     onError: function (err, state, createSend) {
-      var send = createSend('handleError', function (err) {
+      var send = createSend('handleError')
+      send(action, err.message, function (err) {
         // if we hit this point the error handler has failed and we should crash
         if (err) throw err
       })
-      send(action, err.message)
     }
   }
 }


### PR DESCRIPTION
The barracks API isn't great - my bad; this should hopefully fix the issue @Kriesse encountered.

![pasted_image_at_2017_02_14_01_32_pm](https://cloud.githubusercontent.com/assets/2467194/22929743/7a70db00-f2bd-11e6-853b-23a5d7418b04.png)
