### PR TITLE
sets electron window minHeight to 395px

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const windowStyles = {
   height: 600,
   titleBarStyle: 'hidden-inset',
   minWidth: 640,
+  minHeight: 395,
   backgroundColor: colors.neutral
 }
 


### PR DESCRIPTION
Greetings Dat team :wave: 
This pr addresses #252 (no min-height, allowing the window to become very short)

I thought that 395px was a nice min-height.
Screenshots of dat-desktop at the minimum height below:

![screen shot 2017-02-21 at 2 46 43 pm](https://cloud.githubusercontent.com/assets/2081699/23182185/afc3d658-f845-11e6-81f3-b20aed13ec31.png)
![screen shot 2017-02-21 at 2 47 03 pm](https://cloud.githubusercontent.com/assets/2081699/23182188/afcbe618-f845-11e6-8d09-7d3eda14eb20.png)
![screen shot 2017-02-21 at 2 47 37 pm](https://cloud.githubusercontent.com/assets/2081699/23182186/afc5b504-f845-11e6-8219-46de3806365b.png)


