### PR TITLE
Makes welcome screen dismissible with Enter or Space

### DIFF
--- a/pages/main.js
+++ b/pages/main.js
@@ -89,17 +89,12 @@ function mainView (state, prev, send) {
       <div>
         ${sprite()}
         ${WelcomeScreen({
-          onexit: () => send('mainView:toggleWelcomeScreen', { toggle: false }),
-          onload: main => {
+          onexit: () => {
+            window.removeEventListener('keydown', captureKeyEvent)
+            send('mainView:toggleWelcomeScreen', { toggle: false })
+          },
+          onload: () => {
             window.addEventListener('keydown', captureKeyEvent)
-
-            function captureKeyEvent (e) {
-              const key = e.code
-              if (key === 'Enter' || key === 'Space') {
-                window.removeEventListener('keydown', captureKeyEvent)
-                send('mainView:toggleWelcomeScreen', { toggle: false })
-              }
-            }
           }
         })}
       </div>
@@ -123,6 +118,14 @@ function mainView (state, prev, send) {
       ${Table(dats, send)}
     </div>
   `
+
+  function captureKeyEvent (e) {
+    const key = e.code
+    if (key === 'Enter' || key === 'Space') {
+      window.removeEventListener('keydown', captureKeyEvent)
+      send('mainView:toggleWelcomeScreen', { toggle: false })
+    }
+  }
 }
 
 function WelcomeScreen (methods) {

--- a/pages/main.js
+++ b/pages/main.js
@@ -89,7 +89,18 @@ function mainView (state, prev, send) {
       <div>
         ${sprite()}
         ${WelcomeScreen({
-          onexit: () => send('mainView:toggleWelcomeScreen', { toggle: false })
+          onexit: () => send('mainView:toggleWelcomeScreen', { toggle: false }),
+          onload: main => {
+            window.addEventListener('keydown', captureKeyEvent)
+
+            function captureKeyEvent (e) {
+              const key = e.code
+              if (key === 'Enter' || key === 'Space') {
+                window.removeEventListener('keydown', captureKeyEvent)
+                send('mainView:toggleWelcomeScreen', { toggle: false })
+              }
+            }
+          }
         })}
       </div>
     `
@@ -116,8 +127,10 @@ function mainView (state, prev, send) {
 
 function WelcomeScreen (methods) {
   const onExit = methods.onexit
+  const onLoad = methods.onload
+
   return html`
-    <main class="${welcome}">
+    <main class="${welcome}" onload=${onLoad}>
       <img src="./public/img/logo-dat-desktop.svg" alt="" class="">
       <p class="mv4">
         Share data on the distributed web.


### PR DESCRIPTION
This pr addresses #206 (Welcome screen should be dismissible with the keyboard)

With these changes the user can press Space or Enter to dismiss the welcome screen.

At first I tried to add a keypress eventListener to the `<main>` element.  However, I learned that electron [requires a bit of machinery to listen to key events in the DOM](http://stackoverflow.com/questions/40763427/electron-does-not-listen-keydown-event).  I figured that it would be less code across the project if I added a keydown eventListener to the window, and then promptly removed it if the Enter or Space keys were pressed (also on the `onexit` method), and then send an action to the `toggleWelcomeScreen` reducer.

I hope these changes work well for you, and congratulations on the launch!