### PR TITLE
open macos dirs in foreground

### DIFF
--- a/models/repos.js
+++ b/models/repos.js
@@ -121,8 +121,8 @@ function createModel () {
   // open the dat archive in the native filesystem explorer
   function openDirectory (state, data, send, done) {
     assert.ok(data.path, 'repos-model.openDirectory: data.path should exist')
-    shell.openItem(data.path)
-    done()
+    var pathname = 'file://' + path.resolve(data.path)
+    shell.openExternal(pathname, done)
   }
 
   // choose a directory and convert it to a dat archive


### PR DESCRIPTION
https://github.com/datproject/dat-desktop/pull/274 introduced a regression that opened dirs on MacOS in the background - this fixes the regression. Thanks!

- Reference Electron issue: https://github.com/electron/electron/issues/4951