### PR TITLE
upgrade to dat-icons@2

### DIFF
--- a/elements/sprite.js
+++ b/elements/sprite.js
@@ -1,9 +1,0 @@
-const datIcons = require('dat-icons')
-
-module.exports = svgSprite
-
-function svgSprite () {
-  const _el = document.createElement('div')
-  _el.innerHTML = datIcons()
-  return _el.childNodes[0]
-}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dat-colors": "^3.3.0",
     "dat-doctor": "^1.2.2",
     "dat-encoding": "^4.0.1",
-    "dat-icons": "^1.12.0",
+    "dat-icons": "^2.0.0",
     "dat-worker": "^5.10.1",
     "electron-auto-updater": "^0.9.2",
     "electron-default-menu": "^1.0.0",

--- a/pages/main.js
+++ b/pages/main.js
@@ -1,11 +1,11 @@
 'use strict'
 
+const datIcons = require('dat-icons')
 const html = require('choo/html')
 const css = require('sheetify')
 
 const Header = require('../elements/header')
 const button = require('../elements/button')
-const sprite = require('../elements/sprite')
 const Table = require('../elements/table')
 const icon = require('../elements/icon')
 
@@ -89,7 +89,7 @@ function mainView (state, prev, send) {
     document.title = 'Dat Desktop | Welcome'
     return html`
       <div>
-        ${sprite()}
+        ${datIcons()}
         ${WelcomeScreen({
           onexit: () => {
             window.removeEventListener('keydown', captureKeyEvent)
@@ -106,7 +106,7 @@ function mainView (state, prev, send) {
   if (!dats.length) {
     return html`
       <div>
-        ${sprite()}
+        ${datIcons()}
         ${header}
         ${EmptyState()}
       </div>
@@ -115,7 +115,7 @@ function mainView (state, prev, send) {
 
   return html`
     <div>
-      ${sprite()}
+      ${datIcons()}
       ${header}
       ${Table(dats, send)}
     </div>


### PR DESCRIPTION
Upgrades to the latest version of `dat-icons`, removing the need for the sprite boilerplate