### PR TITLE
add global progress indicator. closes #296

### DIFF
--- a/elements/status.js
+++ b/elements/status.js
@@ -83,6 +83,7 @@ module.exports = function (dat, stats, send) {
   if (dat.owner && dat.importer) {
     return html`<div>Watching for updates…</div>`
   }
+  var progress = Math.floor(dat.progress * 100)
   var progressbarLine = (stats.state === 'loading')
     ? 'line-loading'
     : (stats.state === 'paused' || stats.state === 'stale')
@@ -115,10 +116,10 @@ module.exports = function (dat, stats, send) {
     <div>
       <div class="${progressbar}">
         <div class="counter">
-          ${stats.progress}%
+          ${progress}%
         </div>
         <div class="bar">
-          <div class="line ${progressbarLine}" style="width: ${stats.progress}%">
+          <div class="line ${progressbarLine}" style="width: ${progress}%">
           </div>
         </div>
       </div>

--- a/elements/table.js
+++ b/elements/table.js
@@ -144,20 +144,9 @@ function row (dat, send) {
   var key = encoding.encode(dat.key)
   var title = dat.metadata.title || '#' + key
 
-  stats.progress = (!stats)
-    ? 0
-    : (stats.blocksTotal)
-      ? Math.round((stats.blocksProgress / stats.blocksTotal) * 100)
-      : 0
-
-  // place an upper bound of 100% on progress. We've encountered situations
-  // where blocks downloaded exceeds total block. Once that's fixed this
-  // should be safe to be removed
-  stats.progress = Math.min(stats.progress, 100)
   stats.size = (dat.archive.content) ? bytes(dat.archive.content.bytes) : 'N/A'
-
   stats.state = (dat.network)
-    ? (dat.owner || stats.progress === 100)
+    ? (dat.owner || dat.progress === 1)
       ? 'complete'
       : (peers)
         ? 'loading'

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ function onReady () {
   const log = str => mainWindow.webContents.send('log', str)
 
   ipcMain.on('quit', () => app.quit()) // TODO: ping backend with error
+  ipcMain.on('progress', (ev, progress) => mainWindow.setProgressBar(progress))
   emitter.on('open-file', (file) => mainWindow.webContents.send('file', file))
   emitter.on('open-url', (url) => mainWindow.webContents.send('link', url))
 

--- a/models/repos.js
+++ b/models/repos.js
@@ -273,6 +273,24 @@ function createModel () {
 
     function update () {
       var dats = multidat.list().slice()
+      dats.forEach(function (dat) {
+        var stats = dat.stats && dat.stats.get()
+        dat.progress = (!stats)
+          ? 0
+          : (stats.blocksTotal)
+            ? Math.min(1, stats.blocksProgress / stats.blocksTotal)
+            : 0
+      })
+
+      var incomplete = dats.filter(function (dat) {
+        return dat.progress < 1
+      })
+      var progress = incomplete.reduce(function (acc, dat) {
+        return acc + dat.progress
+      }, 0) / incomplete.length
+      if (progress === 1) progress = -1 // deactivate
+
+      ipc.send('progress', progress)
       onupdate(null, dats)
     }
 


### PR DESCRIPTION
This gives us global cross platform process indicators, a la

<img width="43" alt="screen shot 2017-03-09 at 15 10 52" src="https://cloud.githubusercontent.com/assets/10247/23753675/a28f0358-04da-11e7-9c20-0519977ad624.png">

In order to enable this, I moved calculation of a dat's progress value from the views to `models/repos`.

The total progress value is calculated by averaging the individual progress values of all dats who haven't completed yet.