### PR TITLE
models/repos: fix accidental removal of all dats on quit. closes #298

### DIFF
--- a/models/repos.js
+++ b/models/repos.js
@@ -267,7 +267,7 @@ function createModel () {
 
     function closeAll () {
       multidat.list().forEach(function (dat) {
-        multidat.close(dat.key, noop)
+        dat.close(noop)
       })
     }
 


### PR DESCRIPTION
`multidat.close()` also removes the dat from the db, however we only want to "close".