### PR TITLE
add download-finished desktop notification

### DIFF
--- a/models/repos.js
+++ b/models/repos.js
@@ -139,8 +139,7 @@ function createModel () {
   // open the dat archive in the native filesystem explorer
   function openDirectory (state, data, send, done) {
     assert.ok(data.path, 'repos-model.openDirectory: data.path should exist')
-    var pathname = 'file://' + path.resolve(data.path)
-    shell.openExternal(pathname, done)
+    openDatFolder(data.path, done)
   }
 
   // choose a directory and convert it to a dat archive
@@ -281,12 +280,22 @@ function createModel () {
     function update () {
       var dats = multidat.list().slice()
       dats.forEach(function (dat) {
+        var prevProgress = dat.progress
         var stats = dat.stats && dat.stats.get()
         dat.progress = (!stats)
           ? 0
           : (stats.blocksTotal)
             ? Math.min(1, stats.blocksProgress / stats.blocksTotal)
             : 0
+        var unfinishedBefore = prevProgress < 1 && prevProgress > 0
+        if (dat.progress === 1 && unfinishedBefore) {
+          var notification = new Notification('Download finished', {
+            body: dat.metadata.title || dat.key.toString('hex')
+          })
+          notification.onclick = function () {
+            openDatFolder(dat, noop)
+          }
+        }
       })
 
       var incomplete = dats.filter(function (dat) {
@@ -324,4 +333,9 @@ function createModel () {
       dat.on('update', update)
     }
   }
+}
+
+function openDatFolder (dat, cb) {
+  var pathname = 'file://' + path.resolve(dat.path)
+  shell.openExternal(pathname, cb)
 }

--- a/models/repos.js
+++ b/models/repos.js
@@ -15,6 +15,7 @@ const mkdirp = require('mkdirp')
 const path = require('path')
 
 const Modal = require('../elements/modal')
+const noop = function () {}
 
 if (process.env.RUNNING_IN_SPECTRON) {
   dialog.showOpenDialog = (opts, cb) => {
@@ -289,7 +290,7 @@ function createModel () {
             : 0
         var unfinishedBefore = prevProgress < 1 && prevProgress > 0
         if (dat.progress === 1 && unfinishedBefore) {
-          var notification = new Notification('Download finished', {
+          var notification = new window.Notification('Download finished', {
             body: dat.metadata.title || dat.key.toString('hex')
           })
           notification.onclick = function () {


### PR DESCRIPTION
for #20

Notification title `"Download finished"` and notification body `dat.title || key` were the best I could find, there's not too much space inside a notification.

On click, the finder is opened at the dat's directory.