### PR TITLE
Integrate archiver

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,7 @@ persist(opts, (p) => {
   app.model(require('./models/main-view')())
   app.model(require('./models/window')())
   app.model(require('./models/repos')())
+  app.model(require('./models/archiver')())
   app.model(require('./models/error')())
 
   app.router([

--- a/elements/table.js
+++ b/elements/table.js
@@ -206,7 +206,6 @@ function row (dat, send) {
   }
 
   var historyButton = function () {
-    console.log(dat.historical)
     if (dat.historical === undefined) return html`` // loading
     return html`
       <input type="checkbox" checked="${dat.historical}" onclick=${toggleHistory}/>

--- a/elements/table.js
+++ b/elements/table.js
@@ -123,7 +123,8 @@ function tableElement (dats, send) {
             <th class="tl cell-3">Status</th>
             <th class="tr cell-4">Size</th>
             <th class="tl cell-5">Peers</th>
-            <th class="cell-6"></th>
+            <th class="tr cell-6">History</th>
+            <th class="cell-7"></th>
           </tr>
         </thead>
         <tbody>
@@ -189,6 +190,29 @@ function row (dat, send) {
     })
   }[stats.state]
 
+  function getId (target) {
+    let id = null
+    while (target.parentNode) {
+      id = target.getAttribute('id')
+      if (id) break
+      target = target.parentNode
+    }
+    return id
+  }
+
+  function toggleHistory (e) {
+    var id = getId(e.target)
+    send('repos:toggleHistory', {key: id, action: e.target.checked})
+  }
+
+  var historyButton = function () {
+    console.log(dat.historical)
+    if (dat.historical === undefined) return html`` // loading
+    return html`
+      <input type="checkbox" checked="${dat.historical}" onclick=${toggleHistory}/>
+    `
+  }
+
   var finderButton = button.icon('Open in Finder', {
     icon: icon('open-in-finder'),
     class: 'row-action',
@@ -208,11 +232,7 @@ function row (dat, send) {
       // FIXME: we're relying on DOM ordering here. Fix this in choo by moving
       // to nanomorph; e.g. events are still copied over when reordering
       var target = e.target
-      while (target.parentNode) {
-        var id = target.getAttribute('id')
-        if (id) break
-        target = target.parentNode
-      }
+      var id = getId(target)
       assert.equal(typeof id, 'string', 'elements/table.deleteButton: id should be type string')
       send('repos:remove', { key: id })
     }
@@ -261,6 +281,7 @@ function row (dat, send) {
           ${finderButton}
           ${linkButton}
           ${deleteButton}
+          ${historyButton()}
         </div>
       </td>
     </tr>

--- a/models/archiver.js
+++ b/models/archiver.js
@@ -1,0 +1,62 @@
+const Archiver = require('hypercore-archiver')
+const remoteProcess = require('electron').remote.process
+const minimist = require('minimist')
+const waterfall = require('run-waterfall')
+const mkdirp = require('mkdirp')
+const app = require('electron').remote.app
+const path = require('path')
+const Server = require('archiver-server')
+
+module.exports = createModel
+
+function createModel (params) {
+  if (!params) params = {}
+  let archiver = null
+  let server = null
+  const argv = minimist(remoteProcess.argv.slice(2))
+  const dbLocation = argv.db || path.join(process.env.HOME, '.dat-desktop')
+  const dir = path.join(dbLocation, 'archiver')
+
+  return {
+    namespace: 'archiver',
+    state: {
+      dir: dir
+    },
+    subscriptions: {
+      start: createArchiver
+    },
+    effects: {
+      add: add,
+      remove: remove,
+      list: list
+    }
+  }
+
+  function createArchiver (send, done) {
+    const tasks = [
+      function (next) {
+        mkdirp(dir, next)
+      },
+      function () {
+        archiver = Archiver({dir: dir})
+        server = Server(archiver, {swarm: true})
+        app.on('before-quit', function () {
+          server.swarm.destroy()
+        })
+      }
+    ]
+    waterfall(tasks, done)
+  }
+
+  function add (state, data, send, done) {
+    archiver.add(data.key, done)
+  }
+
+  function remove (state, data, send, done) {
+    archiver.remove(data.key, done)
+  }
+
+  function list (state, data, send, done) {
+    archiver.list(done)
+  }
+}

--- a/models/repos.js
+++ b/models/repos.js
@@ -218,9 +218,10 @@ function createModel () {
     const dat = data
     const key = encoding.toStr(dat.key)
 
-    dbMeta.read((err, dat) => {
+    dbMeta.read((err, dats) => {
       if (err) return done(err)
-      if (dat.paused[key]) resume()
+      var meta = dats[key]
+      if (!meta.paused) resume()
       else pause()
     })
 
@@ -298,12 +299,11 @@ function createModel () {
 
     function initDat (dat) {
       const key = encoding.toStr(dat.key)
-      dbMeta.read((err, dat) => {
+      dbMeta.read((err, dats) => {
         if (err) throw err
-        if (!dat.paused[key]) {
-          dat.joinNetwork()
-        }
-        if (dat.historical[key]) dat.historical = true
+        var meta = dats[key]
+        if (!meta || !meta.paused) dat.joinNetwork()
+        if (meta && meta.historical === true) dat.historical = true
         else dat.historical = false
       })
 

--- a/models/repos.js
+++ b/models/repos.js
@@ -201,11 +201,8 @@ function createModel () {
     const dat = data
     const key = encoding.toStr(dat.key)
 
-    dbHistory.read((err, historical) => {
-      if (err) return done(err)
-      if (data.action) add()
-      else remove()
-    })
+    if (data.action) add()
+    else remove()
 
     function add () {
       send('archiver:add', {key: key}, function () {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "description": "Dat Desktop App",
   "author": "Dat Team",
   "dependencies": {
+    "archiver-server": "^2.2.0",
     "base-elements": "^2.2.1",
     "choo": "^4.0.0-6",
     "choo-log": "^3.0.1",
@@ -22,6 +23,7 @@
     "electron-window": "^0.8.1",
     "envobj": "^1.0.2",
     "explain-error": "^1.0.3",
+    "hypercore-archiver": "^3.4.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "ms": "^0.7.2",


### PR DESCRIPTION
We need to think about the UI and can hide the UI for now until we figure it out. I reckon it'd be nice to merge this to force us to support this code-wise.

It changes `dbPaused` to be a metadata db in general for the dats we have on file, so if we decide to add other persistent options we don't end up having a ton of different toiletdb files.

Depends upon an update to toiletdb https://github.com/maxogden/toiletdb/pull/9/files