### PR TITLE
fix app starting before the bundle has been written

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ app.on('ready', () => {
   if (env.NODE_ENV !== 'production') {
     const browserify = require('./lib/browserify')
     const b = browserify({ watch: true })
-    b.once('bundle', onReady)
+    b.once('written', onReady)
   } else {
     onReady()
   }

--- a/lib/browserify.js
+++ b/lib/browserify.js
@@ -52,6 +52,7 @@ module.exports = opts => {
     b.bundle().pipe(concat(js => {
       fs.writeFile(`${__dirname}/../bundle.js`, js, err => {
         if (err) throw err
+        b.emit('written')
         process.stderr.write('ok!\n')
       })
     }))


### PR DESCRIPTION
In dev we would start the app once the bundle was generated, but didn't wait until it was actually written to disk. Sometimes though, you wouldn't see the current version of it.