### PR TITLE
bump choo deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "author": "Dat Team",
   "dependencies": {
     "base-elements": "^2.2.1",
-    "choo": "^5.0.1",
-    "choo-log": "^5.0.1",
+    "choo": "^5.1.0",
+    "choo-log": "^6.0.0",
     "choo-persist": "^3.0.0",
     "console-stream": "juliangruber/console-stream#fix/console",
     "dat-colors": "^3.3.0",


### PR DESCRIPTION
Adds support for choo's timing API added in `v5.1.0` - helps us keep track if our UI is slow (e.g. `<60fps`), which it kinda appears to be 🙁 

<img width="1277" alt="screen shot 2017-03-29 at 11 09 34" src="https://cloud.githubusercontent.com/assets/2467194/24447140/49133ccc-1470-11e7-9009-aa994cad4798.png">
