### PR TITLE
Change copy to be consistent with CLI

### DIFF
--- a/elements/dat-import.js
+++ b/elements/dat-import.js
@@ -68,7 +68,7 @@ function datImportElement (props) {
     <label for="dat-import" class="relative dib pa0 b--none ${prefix}">
       <input name="dat-import"
         type="text"
-        placeholder="Import dat"
+        placeholder="Download"
         onkeydown=${onKeyDown}
         class="input-reset">
       ${icon('link', { class: 'absolute top-0 bottom-0 left-0' })}

--- a/elements/empty.js
+++ b/elements/empty.js
@@ -59,21 +59,21 @@ function EmptyState () {
         <div class="link">
           ${icon('link', { class: 'color-blue-disabled' })}
           <h3 class="f4 ttu mt0 mb0 color-blue-disabled">
-            Import Dat
+            Download A Dat
           </h3>
           <p class="f7 color-neutral-40">
-            Download an existing dataset
+            … and keep data up-to-date
             <br>
-            by entering its dat link…
+            by entering the link here.
           </p>
         </div>
         <div class="tr create-new-dat">
           ${icon('create-new-dat', { class: 'color-green-disabled' })}
-          <h3 class="f4 ttu mt0 mb0 color-green-disabled">Create New Dat</h3>
+          <h3 class="f4 ttu mt0 mb0 color-green-disabled">Share a Folder</h3>
           <p class="f7 color-neutral-40">
-            … or select one of your local
+            … and sync changes by sharing
             <br>
-            datasets and start sharing it.
+             the link with someone else.
           </p>
         </div>
       </div>

--- a/elements/header.js
+++ b/elements/header.js
@@ -78,7 +78,7 @@ function headerElement (props) {
 
   var importButton = datImport({ onsubmit: onimport })
 
-  var createButton = button('Create New Dat', {
+  var createButton = button('Share Folder', {
     id: 'create-new-dat',
     icon: icon('create-new-dat'),
     class: 'ml2 b--transparent header-action header-action-no-border',


### PR DESCRIPTION

<img width="800" alt="screen shot 2017-05-02 at 2 13 29 pm" src="https://cloud.githubusercontent.com/assets/633012/25639676/92b84f20-2f41-11e7-909b-f0aa9b8b58b3.png">

New copy should improve conversion rate of users that go from downloading the binary to sharing data!

CLI uses 'clone' for a Dat -- open to replacing 'download' with that, except right now there is no multi-writer so 'download' is more accurate to what is actually happening here.

Please discuss, thanks! 🎉 
