### PR TITLE
throttle stats updates to once per second. closes #357

### DIFF
--- a/lib/dat-manager.js
+++ b/lib/dat-manager.js
@@ -1,6 +1,7 @@
 const ipc = require('electron').ipcRenderer
 const encoding = require('dat-encoding')
 const shell = require('electron').shell
+const throttle = require('throttleit')
 const assert = require('assert')
 const mkdirp = require('mkdirp')
 const path = require('path')
@@ -172,6 +173,6 @@ function createManager ({ multidat, dbPaused, downloadsDir }, onupdate) {
     if (dat.writable) dat.importFiles()
 
     dat.trackStats()
-    dat.stats.on('update', update)
+    dat.stats.on('update', throttle(update, 1000))
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "run-waterfall": "^1.1.3",
     "sheetify": "^6.0.0",
     "tachyons": "^4.5.4",
+    "throttleit": "^1.0.0",
     "toiletdb": "^1.2.0",
     "xhr": "^2.3.3",
     "xtend": "^4.0.1"


### PR DESCRIPTION
The speed display was updating so fast that it was hard to use, this limits it to one update per second.

In another iteration we can make sure that all the rows update at the same time, in synchronicity.

This also reduces CPU load :)