### PR TITLE
dat-manager: fix metadata handling by reading dat.json from stream, not disk. closes #378

### DIFF
--- a/lib/dat-manager.js
+++ b/lib/dat-manager.js
@@ -152,15 +152,22 @@ function createManager ({ multidat, dbPaused }, onupdate) {
 
     dat.metadata = {}
 
-    var meta = datJson(dat)
-    meta.read(function (err, manifest) {
-      if (err) meta.write(next)
-      else next(null, manifest)
+    dat.archive.readFile('/dat.json', function (err, blob) {
+      if (err && !dat.writable) return
+      if (err) {
+        var json = datJson(dat)
+        json.write(next)
+        return
+      }
+      try {
+        next(null, JSON.parse(blob))
+      } catch (_) {
+        return
+      }
 
-      function next (err, manifest) {
+      function next (err, metadata) {
         if (err) return
-        dat.metadata.title = manifest.title
-        dat.metadata.author = manifest.author
+        Object.assign(dat.metadata, metadata)
         update()
       }
     })


### PR DESCRIPTION
we were only reading the metadata from disk, which wouldn't work in the case where you want to know the meta of a dat that you just began downloading. this patch changes it to _always_ read metadata from the feed, and only write to disk.