### PR TITLE
travis: test on node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 language: node_js
 node_js:
   - 8
-  - 7
+  
 os:
   - osx
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 dist: trusty
 language: node_js
 node_js:
+  - 8
   - 7
 os:
   - osx


### PR DESCRIPTION
npm bundles with node 8 aborts installation if the browserify step fails, see https://github.com/datproject/dat-desktop/issues/436