### PR TITLE
Fix for the order dats are loaded

### DIFF
--- a/lib/dat-manager.js
+++ b/lib/dat-manager.js
@@ -146,6 +146,7 @@ function createManager ({ multidat, dbPaused }, onupdate) {
     const key = encoding.toStr(dat.key)
     dbPaused.read((err, paused) => {
       if (err) throw err
+      if (dat._closed) return
       if (!paused[key]) {
         dat.joinNetwork()
         dat.network.on('connection', function (connection) {
@@ -160,6 +161,7 @@ function createManager ({ multidat, dbPaused }, onupdate) {
 
     dat.archive.readFile('/dat.json', function (err, blob) {
       if (err && !dat.writable) return
+      if (dat._closed) return
       if (err) {
         var json = datJson(dat)
         json.write(next)

--- a/lib/dat-manager.js
+++ b/lib/dat-manager.js
@@ -20,7 +20,9 @@ function createManager ({ multidat, dbPaused }, onupdate) {
   var dats = multidat.list()
   var speed = { up: 0, down: 0 }
   dats.forEach(initDat)
-  onupdate(null, dats, speed)
+  setImmediate(function () {
+    onupdate(null, dats, speed)
+  })
 
   return {
     create: create,

--- a/models/dats.js
+++ b/models/dats.js
@@ -75,9 +75,9 @@ function datsModel (state, bus) {
         state.dats.speed = speed
         state.dats.ready = true
         bus.emit('render')
+        bus.emit('dats:loaded')
+        done()
       })
-      bus.emit('dats:loaded')
-      done()
     }
   ]
 

--- a/models/intro.js
+++ b/models/intro.js
@@ -10,7 +10,7 @@ function introModel (state, bus) {
 
   // FIXME: wait for DOMContentLoaded
   // requires some sort of global load event first
-  bus.on('dats:loaded', function () {
+  bus.once('dats:loaded', function () {
     if (state.dats.values.length) return
     state.intro.show = true
     bus.emit('render')


### PR DESCRIPTION
This PR fixes two things that I found out by trying to change the tests from tape to tap in #453 .

1. On instantiation using `createManager` the `onupdate` call is called **before** the return. Which is a bad case of zalgo that happens to interact with `models/dats` and `models/intro`

2. Timing issues may occur if a dat that is supposed to be deleted or disconnected and then triggers an unexpected event the network connection is established and possibly never stopped.