### PR TITLE
Using new disconnect method to stabilize tests

### DIFF
--- a/lib/dat-manager.js
+++ b/lib/dat-manager.js
@@ -27,6 +27,7 @@ function createManager ({ multidat, dbPaused }, onupdate) {
   return {
     create: create,
     close: close,
+    disconnect: multidat.disconnect,
     pause: pause,
     resume: resume,
     togglePause: togglePause

--- a/package-lock.json
+++ b/package-lock.json
@@ -5991,21 +5991,21 @@
       "integrity": "sha512-PZM4dhYFmCF6uZGWpEmoPMUqJBywS9IcAgybT2GmSpYI1BvGvoWSdbio+ik+q/YD2vodhvslESWIS3NnkKYdqQ=="
     },
     "multidat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/multidat/-/multidat-5.0.2.tgz",
-      "integrity": "sha1-oho8okb6PIfNX7wbeCJzFrTdndc=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/multidat/-/multidat-5.1.0.tgz",
+      "integrity": "sha512-SGRyp4I8ElZv/lbdo9t6tyii13Xd14uPtRglIw3ptFgsBNKq6PH3OYmV9MMfv3LjsjiLimjaO8ZIdQ07wbIv5w==",
       "requires": {
         "dat-node": "3.5.5",
         "explain-error": "1.0.4",
         "fast-json-parse": "1.0.3",
-        "multidrive": "5.1.1",
+        "multidrive": "5.2.0",
         "xtend": "4.0.1"
       }
     },
     "multidrive": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/multidrive/-/multidrive-5.1.1.tgz",
-      "integrity": "sha1-ZQQJLCo/14GfH7xKO/ju4WuwYq0=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/multidrive/-/multidrive-5.2.0.tgz",
+      "integrity": "sha512-3uEuwoR/O0xxI2Do7AewEdk/uOTABcYmBAqAj1YbuEUx8O07v1PNPy7sKEWV4gr70GC+pJNwhIob95ULBfgitg==",
       "requires": {
         "debug": "2.6.9",
         "map-limit": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mirror-folder": "^2.1.0",
     "mkdirp": "^0.5.1",
     "ms": "^0.7.2",
-    "multidat": "^5.0.1",
+    "multidat": "^5.1.0",
     "nanologger": "^1.0.2",
     "nanomorph": "^5.0.0",
     "prettier-bytes": "^1.0.3",


### PR DESCRIPTION
The new `.disconnect` method in https://github.com/datproject/multidat/pull/12 and https://github.com/datproject/multidrive/pull/14 allows to write more stable tests and should leave less connections in limbo if used properly on app shutdown. ~~Since both references PR's are not yet merged this PR is marked `[WIP]`~~